### PR TITLE
Status attribute

### DIFF
--- a/src/modules/control.rng
+++ b/src/modules/control.rng
@@ -6,7 +6,8 @@
     <define name="element.agencyCode">
         <element name="agencyCode">
             <ref name="attribute-group.global-plus-lang-and-script.optional"/>
-            <ref name="attribute.status.authorized-or-alternative.optional"/>
+            <ref name="attribute.status.optional" a:exclude-from="eac"/>
+            <ref name="attribute.status.authorized-or-alternative.optional" a:exclude-from="ead"/>
             <ref name="attribute-group.linked-data.optional"/>
             <text/>
         </element>
@@ -136,7 +137,8 @@
     <define name="element.otherAgencyCode">
         <element name="otherAgencyCode">
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-            <ref name="attribute.status.authorized-or-alternative.optional"/>
+            <ref name="attribute.status.optional" a:exclude-from="eac"/>
+            <ref name="attribute.status.authorized-or-alternative.optional" a:exclude-from="ead"/>
             <ref name="attribute-group.linked-data.optional"/>
             <text/>
         </element>

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -212,7 +212,8 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.standard-date-attributes.optional"/>
-            <ref name="attribute.status.unknown.optional"/>
+            <ref name="attribute.status.optional" a:exclude-from="eac"/>
+            <ref name="attribute.status.unknown.optional" a:exclude-from="ead"/>
             <text/>
         </element>
     </define>  
@@ -286,7 +287,8 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.standard-date-attributes.optional"/>
-            <ref name="attribute.status.unknown.optional"/>
+            <ref name="attribute.status.optional" a:exclude-from="eac"/>
+            <ref name="attribute.status.unknown.optional" a:exclude-from="ead"/>
             <text/>
         </element>
     </define>
@@ -468,7 +470,8 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.standard-date-attributes.optional"/>
-            <ref name="attribute.status.ongoing-or-unknown.optional"/>
+            <ref name="attribute.status.optional" a:exclude-from="eac"/>
+            <ref name="attribute.status.ongoing-or-unknown.optional" a:exclude-from="ead"/>
             <text/>
         </element>
     </define>


### PR DESCRIPTION
Updated agencyCode, otherAgencyCode, date, fromDate, and toDate to not have predefined values in the status attribute in EAD 4.0 anymore; used the a:exclude - once for eac, once for ead - to have the currently different option in parallel for these shared elements

@fordmadox - GitHub shows me an "Able to merge" in comparison to the development branch, but I'll leave it to you to review and approve this pull request; I've only done the changes in the modules source files