### PR TITLE
Update attributes.rng

### DIFF
--- a/src/modules/attributes.rng
+++ b/src/modules/attributes.rng
@@ -362,7 +362,7 @@
         <attribute name="descriptionOfComponentsTypeEncoding" a:defaultValue="EASList">
             <choice>
                 <value>EASList</value>
-                <value>otherdescriptionOfComponentsTypeEncoding</value>
+                <value>otherDescriptionOfComponentsTypeEncoding</value>
             </choice>
         </attribute>
     </define>


### PR DESCRIPTION
Corrected the camelCase spelling for the value "otherDescriptionOfComponentsTypeEncoding" of the attribute descriptionOfComponentsTypeEncoding; 

@fordmadox - I only applied this change in the attributes.rng source file; will leave the review and approval of this pull request to you