### PR TITLE
Update ead-archDesc.rng

### DIFF
--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -571,25 +571,16 @@
     </define>
     
     
-    <!-- are we just keeping this for title?  what gives? -->
     <define name="element.title">
         <element name="title">
-            <ref name="model.controlAccess-element-group"/>
+            <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+            <ref name="attribute-group.assertion-reference.optional"/>
+            <ref name="attribute-group.linked-data.optional"/>
+            <oneOrMore>
+                <ref name="element.part"/>
+            </oneOrMore>
         </element>
     </define>
-    
-    <define name="model.controlAccess-element-group">
-        <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-        <ref name="attribute-group.linked-data.optional"/>
-        <oneOrMore>
-            <ref name="element.part"/>
-        </oneOrMore>
-        <!-- now, available outside of the "relation" element. -->
-        <zeroOrMore>
-            <ref name="element.targetRole"/>
-        </zeroOrMore>
-    </define>
-
   
 
 </grammar>


### PR DESCRIPTION
Updated the definition of title by removing the sub-element targetRole (as title is now only used in findAidDesc that seems an overload) and adding the three ...Reference attributes, which were missing

@fordmadox - I only applied this change in the ead-archDesc.rng module. I've also removed the group definition for controlled access elements as part of this change.

As title is only used in findAidDesc, it might actually make sense to move the element out of ead-archDesc.rng and into ead-findAidDesc.rng (?)