### PR TITLE
Issue 11

### DIFF
--- a/src/modules/attributes.rng
+++ b/src/modules/attributes.rng
@@ -62,13 +62,14 @@
         </optional>  
     </define>
     
+    <!-- Moved the definition of conventionDeclarationReference to the definition of the assertion attributes' group as it is done for the other two attributes there 
     <define name="attribute.conventionDeclarationReference.optional">
         <optional>
             <attribute name="conventionDeclarationReference">
                 <data type="IDREFS"/>
             </attribute>
         </optional>
-    </define>
+    </define> -->
     
     <define name="attribute.coordinateSystem">
         <attribute name="coordinateSystem">
@@ -566,6 +567,13 @@
 
     <define name="attribute-group.assertion-reference.optional" combine="interleave">
         <optional>
+            <attribute name="conventionDeclarationReference">
+                <data type="IDREFS"/>
+            </attribute>
+        </optional>
+    </define>
+    <define name="attribute-group.assertion-reference.optional" combine="interleave">
+        <optional>
             <attribute name="maintenanceEventReference">
                 <data type="IDREFS"/>
             </attribute>
@@ -577,9 +585,6 @@
                 <data type="IDREFS"/>
             </attribute>  
         </optional>
-    </define>
-    <define name="attribute-group.assertion-reference.optional" combine="interleave">
-        <ref name="attribute.conventionDeclarationReference.optional"/>
     </define>
     
     <define name="attribute-group.container.optional" combine="interleave">
@@ -650,10 +655,11 @@
         </optional>
     </define>
  
+    <!-- This group should not be necessary as there shouldn't be a case where we use conventionDeclarationReference without the other two assertion attributes.
     <define name="attribute-group.lang-and-script-and-conventionDeclarationReference.optional" combine="interleave">
         <ref name="attribute-group.lang-and-script.optional"/>
         <ref name="attribute.conventionDeclarationReference.optional"/>
-    </define>
+    </define> -->
     
     <define name="attribute-group.localType.optional">
         <optional>

--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -254,6 +254,7 @@
     <define name="element.descriptionOfComponents">
         <element name="descriptionOfComponents">
             <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.assertion-reference.optional"/>
             <oneOrMore>
                 <choice>
                     <ref name="element.c"/>


### PR DESCRIPTION
Adds the three assertion attributes to descriptionOfComponents and updates the definition of these attributes. Changes were made in the ead-archDesc.rng module and the attributes.rng module. The latter also includes two sections that have been commented out and could possibly be deleted. 