### PR TITLE
Issue 27

### DIFF
--- a/src/ead-source.rng
+++ b/src/ead-source.rng
@@ -23,9 +23,9 @@
         <element name="ead">
             <ref name="attribute-group.document-node"/>
             <ref name="element.control"/>
-            <optional>
+            <zeroOrMore>
                 <ref name="element.findAidDesc"/>
-            </optional>
+            </zeroOrMore>
             <ref name="element.archDesc"/>
         </element>
     </define>

--- a/src/modules/ead-findAidDesc.rng
+++ b/src/modules/ead-findAidDesc.rng
@@ -5,15 +5,15 @@
 
     <define name="element.findAidDesc">
         <element name="findAidDesc">
-            <!-- TO DO: confirm attribute availability -->
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
+            <ref name="attribute-group.links.optional"/>
             <oneOrMore>
                 <choice>
                     <ref name="element.agent"/>
                     <ref name="element.citedRange"/>
                     <ref name="element.date"/>
-                    <ref name="element.formattingExtension.optional"/>
+                    <ref name="element.formattingExtension"/>
                     <ref name="element.place"/>
                     <ref name="element.title"/>
                 </choice>                     

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -4,6 +4,7 @@
     datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     
     <!-- ELEMENTS -->
+    <!-- Could be removed
     <define name="element.abbreviation">
         <element name="abbreviation">
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
@@ -17,6 +18,7 @@
             <text/>
         </element>
     </define>
+    -->
     
     <define name="element.abstract">
         <element name="abstract">
@@ -165,12 +167,9 @@
         </element>
     </define>
     
-
-    
-    
     <!-- regroup what's above later on -->
     
-    <!-- can this be combined now??? I did.  Fix, if needed, after checking with EAC-->
+    <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
     <define name="element.biogHist">
         <element name="biogHist">
             <ref name="model.ead-narrative-elements"/>
@@ -259,15 +258,13 @@
         </optional>
     </define>
     
-    <define name="element.formattingExtension.optional">
-        <optional>
-            <element name="formattingExtension">
-                <ref name="attribute-group.global.optional"/>
-                <oneOrMore>
-                    <ref name="element.anyHTML"/>
-                </oneOrMore>
-            </element>
-        </optional>
+    <define name="element.formattingExtension">
+        <element name="formattingExtension">
+            <ref name="attribute-group.global.optional"/>
+            <oneOrMore>
+                <ref name="element.anyHTML"/>
+            </oneOrMore>
+        </element>
     </define>
     
     <define name="element.anyHTML">
@@ -295,9 +292,7 @@
     
     <define name="element.function">
         <element name="function">
-            
             <ref name="model.single-element-group" a:exclude-from="ead"/>
-            
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional" a:exclude-from="eac"/>
             <ref name="attribute-group.linked-data.optional" a:exclude-from="eac"/>
             <ref name="attribute-group.assertion-reference.optional" a:exclude-from="eac"/>
@@ -314,7 +309,6 @@
             In a future revision of EAC-CPF, <targetType>, <targetRole>, and <relationType> 
             would need to be added as optional and repeatable sub-elements of <function> 
             (we should add these to the single-element-group, if kept as is)
-            
             -->
             <zeroOrMore a:exclude-from="eac">
                 <ref name="element.targetType"/>
@@ -337,7 +331,15 @@
             <data type="normalizedString"/>
         </element>
     </define>
-    
+
+    <define name="element.head.optional">
+        <element name="head">
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
+            <ref name="attribute-group.assertion-reference.optional"/>
+            <ref name="model.mixed-content.optional"/>
+        </element>
+    </define>
+
     <define name="element.language">
         <element name="language">
             <ref name="attribute-group.global-plus-lang-and-script.optional"/>
@@ -570,19 +572,6 @@
         </zeroOrMore>
     </define>
     
-    <define name="model.mixed-content-plus-num.optional">
-        <zeroOrMore>
-            <choice>
-                <!-- is num the only other mixed-content element to survive?  quote, and others are part of HTML, so no need? -->
-                <ref name="element.num"/>
-                <ref name="element.reference"/>
-                <ref name="element.referringString"/>
-                <ref name="element.span"/>
-                <text/>
-            </choice>
-        </zeroOrMore>
-    </define>
-    
     <define name="model.mixed-content-no-references.optional">
         <zeroOrMore>
             <choice>
@@ -596,7 +585,7 @@
     <!-- removing list, with more elements to follow-->
     <define name="model.narrative-group.optional" combine="interleave">
         <zeroOrMore>
-            <ref name="element.formattingExtension.optional"/>
+            <ref name="element.formattingExtension"/>
         </zeroOrMore>
     </define>
     <define name="model.narrative-group.optional" combine="interleave">
@@ -605,7 +594,6 @@
         </zeroOrMore>
     </define>
 
-    
     <!-- where to add num, footnote, and ??? -->
 
      <!-- just EAC currently -->

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -584,9 +584,9 @@
     
     <!-- removing list, with more elements to follow-->
     <define name="model.narrative-group.optional" combine="interleave">
-        <zeroOrMore>
+        <optional>
             <ref name="element.formattingExtension"/>
-        </zeroOrMore>
+        </optional>
     </define>
     <define name="model.narrative-group.optional" combine="interleave">
         <zeroOrMore>


### PR DESCRIPTION
Made "findAidDesc" repeatable, removed "base", added "href", "linkRole" and "linkTitle" and adapted the reference to formattingExtension (which also has been changed in the definition of the shared model). See also pull request from branch "issues_62_63"