### PR TITLE
Issues 62 63

### DIFF
--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -269,6 +269,9 @@
             <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.descriptionOfComponentsType.optional"/>
+            <optional>
+                <ref name="model.narrative-group.optional"/>
+            </optional>
             <oneOrMore>
                 <choice>
                     <ref name="element.c"/>

--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -586,6 +586,7 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.linked-data.optional"/>
+            <ref name="attribute.style.optional"/>
             <oneOrMore>
                 <ref name="element.part"/>
             </oneOrMore>

--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -84,6 +84,7 @@
      
     <define name="element.c">
         <element name="c">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c"/>
@@ -93,6 +94,7 @@
     
     <define name="element.c01">
         <element name="c01">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c02"/>
@@ -102,6 +104,7 @@
     
     <define name="element.c02">
         <element name="c02">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c03"/>
@@ -111,6 +114,7 @@
     
     <define name="element.c03">
         <element name="c03">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c04"/>
@@ -120,6 +124,7 @@
     
     <define name="element.c04">
         <element name="c04">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c05"/>
@@ -129,6 +134,7 @@
     
     <define name="element.c05">
         <element name="c05">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c06"/>
@@ -138,6 +144,7 @@
     
     <define name="element.c06">
         <element name="c06">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c07"/>
@@ -147,6 +154,7 @@
     
     <define name="element.c07">
         <element name="c07">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c08"/>
@@ -156,6 +164,7 @@
     
     <define name="element.c08">
         <element name="c08">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c09"/>
@@ -165,6 +174,7 @@
     
     <define name="element.c09">
         <element name="c09">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c10"/>
@@ -174,6 +184,7 @@
     
     <define name="element.c10">
         <element name="c10">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c11"/>
@@ -183,6 +194,7 @@
     
     <define name="element.c11">
         <element name="c11">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
             <zeroOrMore>
                 <ref name="element.c12"/>
@@ -192,6 +204,7 @@
     
     <define name="element.c12">
         <element name="c12">
+            <ref name="element.head.optional"/>
             <ref name="model.archDesc.levels-of-description"/>
         </element>
     </define>
@@ -230,6 +243,7 @@
         <element name="identificationData">
             <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
+            <ref name="element.head.optional"/>
             <oneOrMore>
                 <choice>
                     <ref name="element.container"/>
@@ -250,7 +264,6 @@
         </element>
     </define>
     
-    <!-- removed head, just as i removed thead from the c elements... okay??? -->
     <define name="element.descriptionOfComponents">
         <element name="descriptionOfComponents">
             <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
@@ -267,7 +280,7 @@
 
     <define name="element.identificationDataNote">
         <element name="identificationDataNote">
-            <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <oneOrMore>
                 <ref name="element.p"/>
@@ -329,15 +342,7 @@
             <ref name="model.mixed-content.optional"/>
         </element>
     </define>
-    
-    <define name="element.num">
-        <element name="num">
-            <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-            <ref name="attribute-group.assertion-reference.optional"/>
-            <ref name="model.mixed-content.optional"/>
-        </element>
-    </define>
-    
+       
     <define name="element.otherDescriptiveInfo">
         <element name="otherDescriptiveInfo">
             <ref name="model.ead-narrative-elements"/>
@@ -401,7 +406,7 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.linked-data.optional"/>
-            <ref name="model.mixed-content-plus-num.optional"/>
+            <ref name="model.mixed-content.optional"/>
         </element>
     </define>
     
@@ -561,7 +566,7 @@
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.linked-data.optional"/>
             <ref name="attribute.label.optional"/>
-            <ref name="model.mixed-content-plus-num.optional"/>
+            <ref name="model.mixed-content.optional"/>
         </element>
     </define>
     

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -4,6 +4,7 @@
     datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     
     <!-- ELEMENTS -->
+    <!-- Could be removed
     <define name="element.abbreviation">
         <element name="abbreviation">
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
@@ -17,6 +18,7 @@
             <text/>
         </element>
     </define>
+    -->
     
     <define name="element.abstract">
         <element name="abstract">
@@ -165,12 +167,9 @@
         </element>
     </define>
     
-
-    
-    
     <!-- regroup what's above later on -->
     
-    <!-- can this be combined now??? I did.  Fix, if needed, after checking with EAC-->
+    <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
     <define name="element.biogHist">
         <element name="biogHist">
             <ref name="model.ead-narrative-elements"/>
@@ -295,9 +294,7 @@
     
     <define name="element.function">
         <element name="function">
-            
             <ref name="model.single-element-group" a:exclude-from="ead"/>
-            
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional" a:exclude-from="eac"/>
             <ref name="attribute-group.linked-data.optional" a:exclude-from="eac"/>
             <ref name="attribute-group.assertion-reference.optional" a:exclude-from="eac"/>
@@ -314,7 +311,6 @@
             In a future revision of EAC-CPF, <targetType>, <targetRole>, and <relationType> 
             would need to be added as optional and repeatable sub-elements of <function> 
             (we should add these to the single-element-group, if kept as is)
-            
             -->
             <zeroOrMore a:exclude-from="eac">
                 <ref name="element.targetType"/>
@@ -337,7 +333,15 @@
             <data type="normalizedString"/>
         </element>
     </define>
-    
+
+    <define name="element.head.optional">
+        <element name="head">
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
+            <ref name="attribute-group.assertion-reference.optional"/>
+            <ref name="model.mixed-content.optional"/>
+        </element>
+    </define>
+
     <define name="element.language">
         <element name="language">
             <ref name="attribute-group.global-plus-lang-and-script.optional"/>
@@ -570,19 +574,6 @@
         </zeroOrMore>
     </define>
     
-    <define name="model.mixed-content-plus-num.optional">
-        <zeroOrMore>
-            <choice>
-                <!-- is num the only other mixed-content element to survive?  quote, and others are part of HTML, so no need? -->
-                <ref name="element.num"/>
-                <ref name="element.reference"/>
-                <ref name="element.referringString"/>
-                <ref name="element.span"/>
-                <text/>
-            </choice>
-        </zeroOrMore>
-    </define>
-    
     <define name="model.mixed-content-no-references.optional">
         <zeroOrMore>
             <choice>
@@ -605,7 +596,6 @@
         </zeroOrMore>
     </define>
 
-    
     <!-- where to add num, footnote, and ??? -->
 
      <!-- just EAC currently -->

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -584,9 +584,9 @@
     
     <!-- removing list, with more elements to follow-->
     <define name="model.narrative-group.optional" combine="interleave">
-        <zeroOrMore>
+        <optional>
             <ref name="element.formattingExtension"/>
-        </zeroOrMore>
+        </optional>
     </define>
     <define name="model.narrative-group.optional" combine="interleave">
         <zeroOrMore>

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -258,15 +258,13 @@
         </optional>
     </define>
     
-    <define name="element.formattingExtension.optional">
-        <optional>
-            <element name="formattingExtension">
-                <ref name="attribute-group.global.optional"/>
-                <oneOrMore>
-                    <ref name="element.anyHTML"/>
-                </oneOrMore>
-            </element>
-        </optional>
+    <define name="element.formattingExtension">
+        <element name="formattingExtension">
+            <ref name="attribute-group.global.optional"/>
+            <oneOrMore>
+                <ref name="element.anyHTML"/>
+            </oneOrMore>
+        </element>
     </define>
     
     <define name="element.anyHTML">
@@ -587,7 +585,7 @@
     <!-- removing list, with more elements to follow-->
     <define name="model.narrative-group.optional" combine="interleave">
         <zeroOrMore>
-            <ref name="element.formattingExtension.optional"/>
+            <ref name="element.formattingExtension"/>
         </zeroOrMore>
     </define>
     <define name="model.narrative-group.optional" combine="interleave">


### PR DESCRIPTION
Re-added the "head" element, which was missing, though still referenced (at the moment) for EAC-CPF (generalContext structureOrGenealogy) as "element.head.optional"; while removed from those elements that include "head" next to the block formatting elements in EAD3, the element is still kept with "identificationData" and the numbered and unnumbered "c" elements.

On the other hand "num" is to be removed (same as the other mixed content element from EAD3) and replaced by "referringString". I have therefore removed the model "model.mixed-content-plus-num.optional".

Also included a comment that "abbreviation" can be deleted.

Added "element.head.optional" to "identificationData" and the numbered and unnumbered "c" elements

Changed the mixed content model for "physFacet" and "unitTitle" from "model.mixed-content-plus-num.optional" to "model.mixed-content.optional"

Changed the attribute group "attribute-group.global-plus-lang-and-script-and-localType-pair.optional" to "attribute-group.global-plus-base-lang-and-script.optional" for "identificationDataNote", i.e. removing "localType" and "localTypeDeclaration"

Changed the definition of formattingExtension from "element.formattingExtension.optional" to "element.formattingExtension" as this had resulted in "formattingExtension" being specifically defined as optional in "findAidDesc", while it should be defined as the other sub-elements of "findAidDesc".

Also renamed the reference in the model "model.narrative-group.optional" accordingly and changed the occurrence of "formattingExtension" from zeroOrMore to optional

Added the choice between "p" and "formattingExtension" to "descriptionOfComponents"