### PR TITLE
Base attribute

### DIFF
--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -228,13 +228,13 @@
      
     <define name="element.identificationData">
         <element name="identificationData">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <oneOrMore>
                 <choice>
                     <ref name="element.container"/>
                     <ref name="element.identificationDataNote"/>
-                    <ref name="element.langMaterial"/>
+                    <ref name="element.languageOfMaterial"/>
                     <ref name="element.legalStatus"/>
                     <ref name="element.materialSpec"/>
                     <ref name="element.physDescSet"/>
@@ -250,10 +250,9 @@
         </element>
     </define>
     
-    <!-- removed head, just as i removed thead from the c elements... okay??? -->
     <define name="element.descriptionOfComponents">
         <element name="descriptionOfComponents">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.descriptionOfComponentsType.optional"/>
             <oneOrMore>
@@ -291,9 +290,9 @@
     </define>
     
     
-    <define name="element.langMaterial">
-        <element name="langMaterial">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+    <define name="element.languageOfMaterial">
+        <element name="languageOfMaterial">
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.label.optional"/>
             <oneOrMore>
@@ -309,7 +308,7 @@
     
     <define name="element.languageSet">
         <element name="languageSet">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <oneOrMore>
                 <ref name="element.language"/>
@@ -360,7 +359,7 @@
     
     <define name="element.physDescSet">
         <element name="physDescSet">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="element.physDescStructured"/>
             <oneOrMore>
@@ -371,17 +370,17 @@
     
     <define name="element.physDescStructured">
         <element name="physDescStructured">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.physDescStructuredType.optional"/>
             <ref name="attribute.coverage.optional"/>
             <element name="quantity">
-                <ref name="attribute-group.global-plus-base.optional"/>
+                <ref name="attribute-group.global-plus-lang-and-script.optional"/>
                 <ref name="attribute-group.assertion-reference.optional"/>
                 <text/>
             </element>
             <element name="unitType">
-                <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+                <ref name="attribute-group.global-plus-lang-and-script.optional"/>
                 <ref name="attribute-group.assertion-reference.optional"/>
                 <ref name="attribute-group.linked-data.optional"/>
                 <text/>
@@ -505,7 +504,7 @@
     
     <define name="element.unitDate">
         <element name="unitDate">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.label.optional"/>
             <ref name="attribute.unitDateType.optional"/>
@@ -525,7 +524,7 @@
     
     <define name="element.unitDateStructured">
         <element name="unitDateStructured">
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.label.optional"/>
             <ref name="attribute.unitDateType.optional"/>

--- a/src/modules/ead-findAidDesc.rng
+++ b/src/modules/ead-findAidDesc.rng
@@ -5,20 +5,20 @@
 
     <define name="element.findAidDesc">
         <element name="findAidDesc">
-            <!-- TO DO: confirm attribute availability -->
-            <ref name="attribute-group.global-plus-base-lang-and-script.optional"/>
+            <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
+            <ref name="attribute-group.links.optional"/>
             <oneOrMore>
                 <choice>
                     <ref name="element.agent"/>
                     <ref name="element.citedRange"/>
                     <ref name="element.date"/>
-                    <ref name="element.formattingExtension.optional"/>
+                    <ref name="element.formattingExtension"/>
                     <ref name="element.place"/>
                     <ref name="element.title"/>
                 </choice>                     
             </oneOrMore>
         </element>       
-    </define>    
+    </define>     
 
 </grammar>


### PR DESCRIPTION
Removed the `@base` attributes from elements that didn't have it in EAD3 as there was no decision to add it to other elements; the elements from which `@base` was removed again are: `<findAidDesc>`, `<identificationData>`, `<descriptionOfComponents>`, `<langMaterial>` (renamed to `<languageOfMaterial>` in this context, see #66), `<physDescSet>`, `<physDescStructured>`, `<unitDate>`, `<unitDateStructured>`, `<languageSet>`, `<quantity>` (to which I also added the missing language attributes), and `<unitType>`