### PR TITLE
Label attribute

### DIFF
--- a/src/modules/attributes.rng
+++ b/src/modules/attributes.rng
@@ -132,14 +132,6 @@
         </optional>
     </define>
     
-    <define name="attribute.label.optional">
-        <optional>
-            <attribute name="label">
-                <data type="token"/>
-            </attribute>
-        </optional>
-    </define>
-    
     <define name="attribute.level.optional">
         <optional>
             <attribute name="level">
@@ -580,10 +572,6 @@
     
     <define name="attribute-group.container.optional" combine="interleave">
         <ref name="attribute.containerId.optional"/>
-    </define>
-    
-    <define name="attribute-group.container.optional" combine="interleave">
-        <ref name="attribute.label.optional"/>
     </define>
     
     <define name="attribute-group.container.optional" combine="interleave">

--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -5,10 +5,6 @@
     datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes">
     
     <!-- to do:     
-        review label attribute
-                localType
-                etc.
-        
         create some updated matrices and use those to refine the existing models... but perhaps wait until more decisions are made? 
                 etc.
         
@@ -315,7 +311,6 @@
         <element name="languageOfMaterial">
             <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
-            <ref name="attribute.label.optional"/>
             <oneOrMore>
                 <choice>
                     <ref name="element.language"/>
@@ -519,7 +514,6 @@
         <element name="unitDate">
             <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
-            <ref name="attribute.label.optional"/>
             <ref name="attribute.unitDateType.optional"/>
             <ref name="attribute.dateChar.optional"/>
             <!-- also bundled together with more attributes for EAC / unidatestructured.
@@ -539,7 +533,6 @@
         <element name="unitDateStructured">
             <ref name="attribute-group.global-plus-lang-and-script.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
-            <ref name="attribute.label.optional"/>
             <ref name="attribute.unitDateType.optional"/>
             <ref name="attribute.dateChar.optional"/>
             <!-- also bundled together with more attributes for EAC / unidatestructured.
@@ -560,7 +553,6 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.linked-data.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
-            <ref name="attribute.label.optional"/>
             <ref name="attribute.countryCode.optional"/>
             <ref name="attribute.repositoryCode.optional"/>
             <ref name="model.mixed-content.optional"/>
@@ -572,7 +564,6 @@
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute-group.linked-data.optional"/>
-            <ref name="attribute.label.optional"/>
             <ref name="model.mixed-content.optional"/>
         </element>
     </define>


### PR DESCRIPTION
Removed `@label` attribute from remaining elements (`<container>`, `<languageOfMaterial>`, `<unitDate>`, `<unitDateStructured>`, `<unitId>`, and `<unitTitle>`); changes done in attributes and ead-archDesc modules