### PR TITLE
Update ead-archDesc.rng

### DIFF
--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -318,7 +318,6 @@
                 </choice>
             </oneOrMore>
             <ref name="element.descriptiveNote.optional"/>
-            <text/>
         </element>
     </define>
     


### PR DESCRIPTION
Hi @fordmadox - while reviewing the sub-elements of `<identificationData>`, I realised that `<languageOfMaterial>` currently allows for text directly in the element, which it shouldn't. I updated the ead-archDesc.rng module and removed this option.