### PR TITLE
Issue 88

### DIFF
--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -515,8 +515,14 @@
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.unitDateType.optional"/>
             <ref name="attribute.dateChar.optional"/>
+            <!-- also bundled together with more attributes for EAC / unidatestructured.
+                for ead4, we should get rid of the structured elements altogether and have a single element that 
+                can be more or less structured depending on sub-elements / attributes.  for now, we've got a mix
+                hence we cannot re-use some of our pre-defined attribute lists just yet.
+            but if we keep the EAD/C separation + UD/UDS separation, then we can combine these 3 attribues with the 4 above for another attribute group model-->
             <ref name="attribute-group.standard-date-attributes.optional"/>
             <ref name="attribute.status.optional" a:exclude-from="eac"/>
+
             <ref name="model.mixed-content.optional"/>
         </element>
     </define>
@@ -527,9 +533,15 @@
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.unitDateType.optional"/>
             <ref name="attribute.dateChar.optional"/>
+            <!-- also bundled together with more attributes for EAC / unidatestructured.
+                for ead4, we should get rid of the structured elements altogether and have a single element that 
+                can be more or less structured depending on sub-elements / attributes.  for now, we've got a mix
+                hence we cannot re-use some of our pre-defined attribute lists just yet.
+            but if we keep the EAD/C separation + UD/UDS separation, then we can combine these 3 attribues with the 4 above for another attribute group model-->
             <ref name="attribute.calendar.optional"/>
             <ref name="attribute.certainty.optional"/>
             <ref name="attribute.era.optional"/>
+
             <ref name="model.all-dates.choice"/>
         </element>
     </define>

--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -515,15 +515,8 @@
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.unitDateType.optional"/>
             <ref name="attribute.dateChar.optional"/>
-            <!-- also bundled together with more attributes for EAC / unidatestructured.
-                for ead4, we should get rid of the structured elements altogether and have a single element that 
-                can be more or less structured depending on sub-elements / attributes.  for now, we've got a mix
-                hence we cannot re-use some of our pre-defined attribute lists just yet.
-            but if we keep the EAD/C separation + UD/UDS separation, then we can combine these 3 attribues with the 4 above for another attribute group model-->
-            <ref name="attribute.calendar.optional"/>
-            <ref name="attribute.certainty.optional"/>
-            <ref name="attribute.era.optional"/>
-
+            <ref name="attribute-group.standard-date-attributes.optional"/>
+            <ref name="attribute.status.optional" a:exclude-from="eac"/>
             <ref name="model.mixed-content.optional"/>
         </element>
     </define>
@@ -534,15 +527,9 @@
             <ref name="attribute-group.assertion-reference.optional"/>
             <ref name="attribute.unitDateType.optional"/>
             <ref name="attribute.dateChar.optional"/>
-            <!-- also bundled together with more attributes for EAC / unidatestructured.
-                for ead4, we should get rid of the structured elements altogether and have a single element that 
-                can be more or less structured depending on sub-elements / attributes.  for now, we've got a mix
-                hence we cannot re-use some of our pre-defined attribute lists just yet.
-            but if we keep the EAD/C separation + UD/UDS separation, then we can combine these 3 attribues with the 4 above for another attribute group model-->
             <ref name="attribute.calendar.optional"/>
             <ref name="attribute.certainty.optional"/>
             <ref name="attribute.era.optional"/>
-
             <ref name="model.all-dates.choice"/>
         </element>
     </define>


### PR DESCRIPTION
Added the attribute-group.standard-date-attributes.optional to `<unitDate>`, removing the separately mentioned `@calendar`, `@era`, and `@certainty`. 

Also added `@status` to `<unitDate>`.