### PR TITLE
135 add ISO3166 2 as a value for countryencoding and replace iso639 2 with the more specific options iso639 2b and iso639 2t for languageencoding

### DIFF
--- a/src/modules/attributes.rng
+++ b/src/modules/attributes.rng
@@ -392,11 +392,14 @@
     </define>
     
     <define name="attribute.languageEncoding">
-        <attribute name="languageEncoding" a:defaultValue="iso639-2">
+        <attribute name="languageEncoding">
             <choice>
                 <value>iso639-1</value>
                 <value>iso639-2</value>
+                <value>iso639-2b</value>
+                <value>iso639-2t</value>
                 <value>iso639-3</value>
+                <value>iso639-5</value>
                 <value>ietf-bcp-47</value>
                 <value>otherLanguageEncoding</value>
             </choice>

--- a/src/modules/attributes.rng
+++ b/src/modules/attributes.rng
@@ -332,9 +332,13 @@
     </define>
     
     <define name="attribute.countryEncoding">
-        <attribute name="countryEncoding" a:defaultValue="iso3166-1">
+        <attribute name="countryEncoding">
             <choice>
-                <value>iso3166-1</value>
+                <value>iso3166-1-alpha-2</value>
+                <value>iso3166-1-alpha-3</value>
+                <value>iso3166-1-numeric</value>
+                <value>iso3166-2</value>
+                <value>iso3166-3</value>
                 <value>otherCountryEncoding</value>
             </choice>
         </attribute>

--- a/src/modules/extensible-version/ead/modules/attributes.rng
+++ b/src/modules/extensible-version/ead/modules/attributes.rng
@@ -291,9 +291,13 @@
       </attribute>
    </define>
    <define name="attribute.countryEncoding">
-      <attribute name="countryEncoding" a:defaultValue="iso3166-1">
+      <attribute name="countryEncoding">
          <choice>
-            <value>iso3166-1</value>
+            <value>iso3166-1-alpha-2</value>
+            <value>iso3166-1-alpha-3</value>
+            <value>iso3166-1-numeric</value>
+            <value>iso3166-2</value>
+            <value>iso3166-3</value>
             <value>otherCountryEncoding</value>
          </choice>
       </attribute>
@@ -345,11 +349,14 @@
       </attribute>
    </define>
    <define name="attribute.languageEncoding">
-      <attribute name="languageEncoding" a:defaultValue="iso639-2">
+      <attribute name="languageEncoding">
          <choice>
             <value>iso639-1</value>
             <value>iso639-2</value>
+            <value>iso639-2b</value>
+            <value>iso639-2t</value>
             <value>iso639-3</value>
+            <value>iso639-5</value>
             <value>ietf-bcp-47</value>
             <value>otherLanguageEncoding</value>
          </choice>

--- a/xml-schemas/ead/ead-4-dev.rng
+++ b/xml-schemas/ead/ead-4-dev.rng
@@ -151,7 +151,11 @@
             <optional>
                <attribute name="countryEncoding" ns="">
                   <choice>
-                     <value type="token" datatypeLibrary="" ns="">iso3166-1</value>
+                     <value type="token" datatypeLibrary="" ns="">iso3166-1-alpha-2</value>
+                     <value type="token" datatypeLibrary="" ns="">iso3166-1-alpha-3</value>
+                     <value type="token" datatypeLibrary="" ns="">iso3166-1-numeric</value>
+                     <value type="token" datatypeLibrary="" ns="">iso3166-2</value>
+                     <value type="token" datatypeLibrary="" ns="">iso3166-3</value>
                      <value type="token" datatypeLibrary="" ns="">otherCountryEncoding</value>
                   </choice>
                </attribute>
@@ -193,7 +197,10 @@
                   <choice>
                      <value type="token" datatypeLibrary="" ns="">iso639-1</value>
                      <value type="token" datatypeLibrary="" ns="">iso639-2</value>
+                     <value type="token" datatypeLibrary="" ns="">iso639-2b</value>
+                     <value type="token" datatypeLibrary="" ns="">iso639-2t</value>
                      <value type="token" datatypeLibrary="" ns="">iso639-3</value>
+                     <value type="token" datatypeLibrary="" ns="">iso639-5</value>
                      <value type="token" datatypeLibrary="" ns="">ietf-bcp-47</value>
                      <value type="token" datatypeLibrary="" ns="">otherLanguageEncoding</value>
                   </choice>

--- a/xml-schemas/ead/ead-4-dev.xsd
+++ b/xml-schemas/ead/ead-4-dev.xsd
@@ -79,7 +79,11 @@
       <xs:attribute name="countryEncoding">
          <xs:simpleType>
             <xs:restriction base="xs:token">
-               <xs:enumeration value="iso3166-1"/>
+               <xs:enumeration value="iso3166-1-alpha-2"/>
+               <xs:enumeration value="iso3166-1-alpha-3"/>
+               <xs:enumeration value="iso3166-1-numeric"/>
+               <xs:enumeration value="iso3166-2"/>
+               <xs:enumeration value="iso3166-3"/>
                <xs:enumeration value="otherCountryEncoding"/>
             </xs:restriction>
          </xs:simpleType>
@@ -121,7 +125,10 @@
             <xs:restriction base="xs:token">
                <xs:enumeration value="iso639-1"/>
                <xs:enumeration value="iso639-2"/>
+               <xs:enumeration value="iso639-2b"/>
+               <xs:enumeration value="iso639-2t"/>
                <xs:enumeration value="iso639-3"/>
+               <xs:enumeration value="iso639-5"/>
                <xs:enumeration value="ietf-bcp-47"/>
                <xs:enumeration value="otherLanguageEncoding"/>
             </xs:restriction>


### PR DESCRIPTION
Note:  the ticket listed iso3166-2 twice, but I'm pretty certain the latter was intended to be iso1366-3.