### PR TITLE
118 add provenanceevent as a new type of event life cycle traceability in selected narrative elements

### DIFF
--- a/src/modules/ead-archDesc.rng
+++ b/src/modules/ead-archDesc.rng
@@ -54,13 +54,13 @@
 
     <define name="element.sourceOfAcquisition">
         <element name="sourceOfAcquisition">
-            <ref name="model.ead-narrative-elements"/>
+            <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
         </element>
     </define>
     
     <define name="element.appraisal">
         <element name="appraisal">
-            <ref name="model.ead-narrative-elements"/>
+            <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
         </element>
     </define>
     
@@ -235,7 +235,7 @@
     
     <define name="element.custodHist">
         <element name="custodHist">
-            <ref name="model.ead-narrative-elements"/>
+            <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
         </element>
     </define>
      
@@ -437,8 +437,23 @@
     
     <define name="element.processInfo">
         <element name="processInfo">
-            <ref name="model.ead-narrative-elements"/>
+            <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
         </element>
+    </define>
+    
+    <define name="element.provenanceEvent">
+        <element name="provenanceEvent">
+            <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+            <ref name="attribute-group.assertion-reference.optional"/>
+            <!-- like maintenanceEvent, but not really, due to different options -->
+            <ref name="element.eventDateTime"/>
+            <optional>
+                <ref name="element.agent"/>
+            </optional>
+            <zeroOrMore>
+                <ref name="element.eventDescription"/>
+            </zeroOrMore>
+        </element>   
     </define>
     
     <!-- not needed for long, right? -->

--- a/src/modules/extensible-version/ead/modules/ead-archDesc.rng
+++ b/src/modules/extensible-version/ead/modules/ead-archDesc.rng
@@ -47,12 +47,12 @@
    </define>
    <define name="element.sourceOfAcquisition">
       <element name="sourceOfAcquisition">
-         <ref name="model.ead-narrative-elements"/>
+         <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
       </element>
    </define>
    <define name="element.appraisal">
       <element name="appraisal">
-         <ref name="model.ead-narrative-elements"/>
+         <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
       </element>
    </define>
    <define name="element.archDesc">
@@ -209,7 +209,7 @@
    </define>
    <define name="element.custodHist">
       <element name="custodHist">
-         <ref name="model.ead-narrative-elements"/>
+         <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
       </element>
    </define>
    <define name="element.identificationData">
@@ -392,7 +392,21 @@
    </define>
    <define name="element.processInfo">
       <element name="processInfo">
-         <ref name="model.ead-narrative-elements"/>
+         <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
+      </element>
+   </define>
+   <define name="element.provenanceEvent">
+      <element name="provenanceEvent">
+         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+         <ref name="attribute-group.assertion-reference.optional"/>
+         <!-- like maintenanceEvent, but not really, due to different options -->
+         <ref name="element.eventDateTime"/>
+         <optional>
+            <ref name="element.agent"/>
+         </optional>
+         <zeroOrMore>
+            <ref name="element.eventDescription"/>
+         </zeroOrMore>
       </element>
    </define>
    <!-- not needed for long, right? -->

--- a/src/modules/extensible-version/ead/modules/models-and-shared-elements.rng
+++ b/src/modules/extensible-version/ead/modules/models-and-shared-elements.rng
@@ -157,7 +157,9 @@
    <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
    <define name="element.biogHist">
       <element name="biogHist">
-         <ref name="model.ead-narrative-elements"/>
+            <!-- note the EAC impact. the goal is no differences, but so we might need to add provenanceEvent to EAC, or 
+            remove biogHist from EAD ? -->
+         <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
       </element>
    </define>
    <define name="element.citedRange">
@@ -500,6 +502,17 @@
       <optional>
          <ref name="element.abstract"/>
       </optional>
+      <ref name="model.narrative-group.optional"/>
+   </define>
+   <define name="model.ead-narrative-elements-plus-provenanceEvent">
+      <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+      <ref name="attribute-group.assertion-reference.optional"/>
+      <optional>
+         <ref name="element.abstract"/>
+      </optional>
+      <zeroOrMore>
+         <ref name="element.provenanceEvent"/>
+      </zeroOrMore>
       <ref name="model.narrative-group.optional"/>
    </define>
    <!-- note: this will continue to simplify, once table is removed, etc... for bibliography (now 'publicationNote'), otherFindAid, separatedMaterial, and relatedMaterial.... rename it to something that makes sense, and remodel it -->

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -170,7 +170,9 @@
     <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
     <define name="element.biogHist">
         <element name="biogHist">
-            <ref name="model.ead-narrative-elements"/>
+            <!-- note the EAC impact. the goal is no differences, but so we might need to add provenanceEvent to EAC, or 
+            remove biogHist from EAD ? -->
+            <ref name="model.ead-narrative-elements-plus-provenanceEvent"/>
         </element>
     </define>
     
@@ -551,6 +553,19 @@
         </optional>
         <ref name="model.narrative-group.optional"/>
     </define>
+    
+    <define name="model.ead-narrative-elements-plus-provenanceEvent">
+        <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+        <ref name="attribute-group.assertion-reference.optional"/>
+        <optional>
+            <ref name="element.abstract"/>
+        </optional>
+        <zeroOrMore>
+            <ref name="element.provenanceEvent"/>
+        </zeroOrMore>
+        <ref name="model.narrative-group.optional"/>
+    </define>
+
     
     <!-- note: this will continue to simplify, once table is removed, etc... for bibliography (now 'publicationNote'), otherFindAid, separatedMaterial, and relatedMaterial.... rename it to something that makes sense, and remodel it -->
     <define name="model.ead-narrative-elements-plus-relations">

--- a/xml-schemas/ead/ead-4-dev.rng
+++ b/xml-schemas/ead/ead-4-dev.rng
@@ -2591,6 +2591,9 @@
             <optional>
                <ref name="abstract"/>
             </optional>
+            <zeroOrMore>
+               <ref name="provenanceEvent"/>
+            </zeroOrMore>
             <choice>
                <optional>
                   <ref name="formattingExtension"/>
@@ -2781,6 +2784,9 @@
             <optional>
                <ref name="abstract"/>
             </optional>
+            <zeroOrMore>
+               <ref name="provenanceEvent"/>
+            </zeroOrMore>
             <choice>
                <optional>
                   <ref name="formattingExtension"/>
@@ -2876,6 +2882,9 @@
             <optional>
                <ref name="abstract"/>
             </optional>
+            <zeroOrMore>
+               <ref name="provenanceEvent"/>
+            </zeroOrMore>
             <choice>
                <optional>
                   <ref name="formattingExtension"/>
@@ -3470,6 +3479,9 @@
             <optional>
                <ref name="abstract"/>
             </optional>
+            <zeroOrMore>
+               <ref name="provenanceEvent"/>
+            </zeroOrMore>
             <choice>
                <optional>
                   <ref name="formattingExtension"/>
@@ -4014,6 +4026,9 @@
             <optional>
                <ref name="abstract"/>
             </optional>
+            <zeroOrMore>
+               <ref name="provenanceEvent"/>
+            </zeroOrMore>
             <choice>
                <optional>
                   <ref name="formattingExtension"/>
@@ -8103,6 +8118,97 @@
                   <text/>
                </choice>
             </oneOrMore>
+         </group>
+      </element>
+   </define>
+   <define name="provenanceEvent">
+      <element name="provenanceEvent" ns="https://archivists.org/ns/ead/v4">
+         <group>
+            <interleave>
+               <optional>
+                  <attribute name="audience" ns="">
+                     <data type="token"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+               <optional>
+                  <attribute name="id" ns="">
+                     <data type="ID" datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+               <optional>
+                  <attribute name="target" ns="">
+                     <data type="IDREFS"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+               <zeroOrMore>
+                  <attribute>
+                     <anyName>
+                        <except>
+                           <choice>
+                              <nsName ns="https://archivists.org/ns/ead/v4"/>
+                              <nsName ns=""/>
+                           </choice>
+                        </except>
+                     </anyName>
+                     <text/>
+                  </attribute>
+               </zeroOrMore>
+            </interleave>
+            <interleave>
+               <optional>
+                  <attribute name="languageOfElement" ns="">
+                     <data type="token"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+               <optional>
+                  <attribute name="scriptOfElement" ns="">
+                     <data type="token"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+            </interleave>
+            <optional>
+               <attribute name="localType" ns="">
+                  <data type="token"
+                        datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+               </attribute>
+            </optional>
+            <optional>
+               <attribute name="localTypeDeclarationReference" ns="">
+                  <data type="IDREFS"
+                        datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+               </attribute>
+            </optional>
+            <interleave>
+               <optional>
+                  <attribute name="conventionDeclarationReference" ns="">
+                     <data type="IDREFS"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+               <optional>
+                  <attribute name="maintenanceEventReference" ns="">
+                     <data type="IDREFS"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+               <optional>
+                  <attribute name="sourceReference" ns="">
+                     <data type="IDREFS"
+                           datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
+                  </attribute>
+               </optional>
+            </interleave>
+            <ref name="eventDateTime"/>
+            <optional>
+               <ref name="agent"/>
+            </optional>
+            <zeroOrMore>
+               <ref name="eventDescription"/>
+            </zeroOrMore>
          </group>
       </element>
    </define>

--- a/xml-schemas/ead/ead-4-dev.xsd
+++ b/xml-schemas/ead/ead-4-dev.xsd
@@ -699,6 +699,10 @@
    <xs:complexType name="appraisal">
       <xs:sequence>
          <xs:element type="ead:abstract" name="abstract" minOccurs="0"/>
+         <xs:element type="ead:provenanceEvent"
+                     name="provenanceEvent"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
          <xs:choice>
             <xs:element type="ead:formattingExtension"
                         name="formattingExtension"
@@ -743,6 +747,10 @@
    <xs:complexType name="biogHist">
       <xs:sequence>
          <xs:element type="ead:abstract" name="abstract" minOccurs="0"/>
+         <xs:element type="ead:provenanceEvent"
+                     name="provenanceEvent"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
          <xs:choice>
             <xs:element type="ead:formattingExtension"
                         name="formattingExtension"
@@ -765,6 +773,10 @@
    <xs:complexType name="custodHist">
       <xs:sequence>
          <xs:element type="ead:abstract" name="abstract" minOccurs="0"/>
+         <xs:element type="ead:provenanceEvent"
+                     name="provenanceEvent"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
          <xs:choice>
             <xs:element type="ead:formattingExtension"
                         name="formattingExtension"
@@ -901,6 +913,10 @@
    <xs:complexType name="processInfo">
       <xs:sequence>
          <xs:element type="ead:abstract" name="abstract" minOccurs="0"/>
+         <xs:element type="ead:provenanceEvent"
+                     name="provenanceEvent"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
          <xs:choice>
             <xs:element type="ead:formattingExtension"
                         name="formattingExtension"
@@ -1023,6 +1039,10 @@
    <xs:complexType name="sourceOfAcquisition">
       <xs:sequence>
          <xs:element type="ead:abstract" name="abstract" minOccurs="0"/>
+         <xs:element type="ead:provenanceEvent"
+                     name="provenanceEvent"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
          <xs:choice>
             <xs:element type="ead:formattingExtension"
                         name="formattingExtension"
@@ -1846,6 +1866,27 @@
       <xs:attribute name="target" type="xs:IDREFS"/>
       <xs:attribute name="languageOfElement" type="xs:token"/>
       <xs:attribute name="scriptOfElement" type="xs:token"/>
+      <xs:attribute name="conventionDeclarationReference" type="xs:IDREFS"/>
+      <xs:attribute name="maintenanceEventReference" type="xs:IDREFS"/>
+      <xs:attribute name="sourceReference" type="xs:IDREFS"/>
+      <xs:anyAttribute namespace="##other" processContents="lax"/>
+   </xs:complexType>
+   <xs:complexType name="provenanceEvent">
+      <xs:sequence>
+         <xs:element type="ead:eventDateTime" name="eventDateTime"/>
+         <xs:element type="ead:agent" name="agent" minOccurs="0"/>
+         <xs:element type="ead:eventDescription"
+                     name="eventDescription"
+                     minOccurs="0"
+                     maxOccurs="unbounded"/>
+      </xs:sequence>
+      <xs:attribute name="audience" type="xs:token"/>
+      <xs:attribute name="id" type="xs:ID"/>
+      <xs:attribute name="target" type="xs:IDREFS"/>
+      <xs:attribute name="languageOfElement" type="xs:token"/>
+      <xs:attribute name="scriptOfElement" type="xs:token"/>
+      <xs:attribute name="localType" type="xs:token"/>
+      <xs:attribute name="localTypeDeclarationReference" type="xs:IDREFS"/>
       <xs:attribute name="conventionDeclarationReference" type="xs:IDREFS"/>
       <xs:attribute name="maintenanceEventReference" type="xs:IDREFS"/>
       <xs:attribute name="sourceReference" type="xs:IDREFS"/>


### PR DESCRIPTION
This is a new iteration of #182 to merge into the branch for this year's release rather than last year's. There is a pending question re the sequence of sub-elements in the related issue #118.