### PR TITLE
238-eac-cpfead-subelements-narrativeevent

### DIFF
--- a/src/modules/extensible-version/eac/modules/models-and-shared-elements.rng
+++ b/src/modules/extensible-version/eac/modules/models-and-shared-elements.rng
@@ -79,16 +79,9 @@
       </element>
    </define>
    <!-- regroup what's above later on -->
-   <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
    <define name="element.biogHist" a:exclude-from="eaf">
       <element name="biogHist">
-            <!-- note the EAC impact. the goal is no differences, but so we might need to add narrativeEvent to EAC, or 
-            remove biogHist from EAD ? -->
          <ref name="model.ead-narrative-elements-plus-narrativeEvent"/>
-         <!-- Or, yuck, but... 
-            <ref name="model.ead-narrative-elements-plus-narrativeEvent" a:exclude-from="eac eaf"/>
-            <ref name="model.ead-narrative-elements" a:exclude-from="ead"/>
-            -->
       </element>
    </define>
    <define name="element.citedRange">
@@ -279,6 +272,22 @@
          </zeroOrMore>
       </element>
    </define>
+   <define name="element.narrativeEvent">
+      <element name="narrativeEvent">
+         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+         <ref name="attribute-group.assertion-reference.optional"/>
+         <oneOrMore>
+            <ref name="element.date"/>
+         </oneOrMore>
+         <zeroOrMore>
+            <choice>
+               <ref name="element.agent"/>
+               <ref name="element.placeName"/>
+               <ref name="element.eventDescription"/>
+            </choice>
+         </zeroOrMore>
+      </element>
+   </define>
    <define name="element.objectXMLWrap.optional">
       <optional>
          <element name="objectXMLWrap">
@@ -336,22 +345,6 @@
          <ref name="attribute-group.assertion-reference.optional"/>
          <ref name="attribute.countryCode.optional"/>
          <text/>
-      </element>
-   </define>
-   <define name="element.narrativeEvent">
-      <element name="narrativeEvent">
-         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-         <ref name="attribute-group.assertion-reference.optional"/>
-         <ref name="element.date"/>
-         <optional>
-            <ref name="element.agent"/>
-         </optional>
-         <optional>
-            <ref name="element.placeName"/>
-         </optional>
-         <zeroOrMore>
-            <ref name="element.eventDescription"/>
-         </zeroOrMore>
       </element>
    </define>
    <define name="element.recordTypeSpecificStatement">

--- a/src/modules/extensible-version/ead/modules/models-and-shared-elements.rng
+++ b/src/modules/extensible-version/ead/modules/models-and-shared-elements.rng
@@ -126,16 +126,9 @@
       </element>
    </define>
    <!-- regroup what's above later on -->
-   <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
    <define name="element.biogHist" a:exclude-from="eaf">
       <element name="biogHist">
-            <!-- note the EAC impact. the goal is no differences, but so we might need to add narrativeEvent to EAC, or 
-            remove biogHist from EAD ? -->
          <ref name="model.ead-narrative-elements-plus-narrativeEvent"/>
-         <!-- Or, yuck, but... 
-            <ref name="model.ead-narrative-elements-plus-narrativeEvent" a:exclude-from="eac eaf"/>
-            <ref name="model.ead-narrative-elements" a:exclude-from="ead"/>
-            -->
       </element>
    </define>
    <define name="element.citedRange">
@@ -332,6 +325,22 @@
          </zeroOrMore>
       </element>
    </define>
+   <define name="element.narrativeEvent">
+      <element name="narrativeEvent">
+         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+         <ref name="attribute-group.assertion-reference.optional"/>
+         <oneOrMore>
+            <ref name="element.date"/>
+         </oneOrMore>
+         <zeroOrMore>
+            <choice>
+               <ref name="element.agent"/>
+               <ref name="element.placeName"/>
+               <ref name="element.eventDescription"/>
+            </choice>
+         </zeroOrMore>
+      </element>
+   </define>
    <define name="element.objectXMLWrap.optional">
       <optional>
          <element name="objectXMLWrap">
@@ -389,22 +398,6 @@
          <ref name="attribute-group.assertion-reference.optional"/>
          <ref name="attribute.countryCode.optional"/>
          <text/>
-      </element>
-   </define>
-   <define name="element.narrativeEvent">
-      <element name="narrativeEvent">
-         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-         <ref name="attribute-group.assertion-reference.optional"/>
-         <ref name="element.date"/>
-         <optional>
-            <ref name="element.agent"/>
-         </optional>
-         <optional>
-            <ref name="element.placeName"/>
-         </optional>
-         <zeroOrMore>
-            <ref name="element.eventDescription"/>
-         </zeroOrMore>
       </element>
    </define>
    <define name="element.recordTypeSpecificStatement">

--- a/src/modules/extensible-version/eaf/modules/models-and-shared-elements.rng
+++ b/src/modules/extensible-version/eaf/modules/models-and-shared-elements.rng
@@ -79,7 +79,6 @@
       </element>
    </define>
    <!-- regroup what's above later on -->
-   <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
    <define name="element.citedRange">
       <element name="citedRange">
          <ref name="attribute-group.global-plus-lang-and-script.optional"/>
@@ -268,6 +267,22 @@
          </zeroOrMore>
       </element>
    </define>
+   <define name="element.narrativeEvent">
+      <element name="narrativeEvent">
+         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+         <ref name="attribute-group.assertion-reference.optional"/>
+         <oneOrMore>
+            <ref name="element.date"/>
+         </oneOrMore>
+         <zeroOrMore>
+            <choice>
+               <ref name="element.agent"/>
+               <ref name="element.placeName"/>
+               <ref name="element.eventDescription"/>
+            </choice>
+         </zeroOrMore>
+      </element>
+   </define>
    <define name="element.objectXMLWrap.optional">
       <optional>
          <element name="objectXMLWrap">
@@ -325,22 +340,6 @@
          <ref name="attribute-group.assertion-reference.optional"/>
          <ref name="attribute.countryCode.optional"/>
          <text/>
-      </element>
-   </define>
-   <define name="element.narrativeEvent">
-      <element name="narrativeEvent">
-         <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-         <ref name="attribute-group.assertion-reference.optional"/>
-         <ref name="element.date"/>
-         <optional>
-            <ref name="element.agent"/>
-         </optional>
-         <optional>
-            <ref name="element.placeName"/>
-         </optional>
-         <zeroOrMore>
-            <ref name="element.eventDescription"/>
-         </zeroOrMore>
       </element>
    </define>
    <define name="element.recordTypeSpecificStatement">

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -354,6 +354,23 @@
             </zeroOrMore>
         </element>
     </define>
+    
+    <define name="element.narrativeEvent">
+        <element name="narrativeEvent">
+            <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
+            <ref name="attribute-group.assertion-reference.optional"/>
+            <oneOrMore>            
+                <ref name="element.date"/>
+            </oneOrMore>
+            <zeroOrMore>
+                <choice>
+                    <ref name="element.agent"/>
+                    <ref name="element.placeName"/>
+                    <ref name="element.eventDescription"/>
+                </choice>
+            </zeroOrMore>
+        </element>   
+    </define>
 
     <define name="element.objectXMLWrap.optional">
         <optional>
@@ -417,23 +434,6 @@
             <ref name="attribute.countryCode.optional"/>
             <text/>
         </element>
-    </define>
-    
-    <define name="element.narrativeEvent">
-        <element name="narrativeEvent">
-            <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
-            <ref name="attribute-group.assertion-reference.optional"/>
-            <oneOrMore>            
-                <ref name="element.date"/>
-            </oneOrMore>
-            <zeroOrMore>
-                <choice>
-                    <ref name="element.agent"/>
-                    <ref name="element.placeName"/>
-                    <ref name="element.eventDescription"/>
-                </choice>
-            </zeroOrMore>
-        </element>   
     </define>
 
     <define name="element.recordTypeSpecificStatement">

--- a/src/modules/models-and-shared-elements.rng
+++ b/src/modules/models-and-shared-elements.rng
@@ -137,16 +137,9 @@
     
     <!-- regroup what's above later on -->
     
-    <!-- can this be combined now??? I did. Fix, if needed, after checking with EAC -->
     <define name="element.biogHist" a:exclude-from="eaf">
         <element name="biogHist">
-            <!-- note the EAC impact. the goal is no differences, but so we might need to add narrativeEvent to EAC, or 
-            remove biogHist from EAD ? -->
             <ref name="model.ead-narrative-elements-plus-narrativeEvent"/>
-            <!-- Or, yuck, but... 
-            <ref name="model.ead-narrative-elements-plus-narrativeEvent" a:exclude-from="eac eaf"/>
-            <ref name="model.ead-narrative-elements" a:exclude-from="ead"/>
-            -->
         </element>
     </define>
     
@@ -430,15 +423,15 @@
         <element name="narrativeEvent">
             <ref name="attribute-group.global-plus-lang-and-script-and-localType-pair.optional"/>
             <ref name="attribute-group.assertion-reference.optional"/>
-            <ref name="element.date"/>
-            <optional>
-                <ref name="element.agent"/>
-            </optional>
-            <optional>
-                <ref name="element.placeName"/>
-            </optional>
+            <oneOrMore>            
+                <ref name="element.date"/>
+            </oneOrMore>
             <zeroOrMore>
-                <ref name="element.eventDescription"/>
+                <choice>
+                    <ref name="element.agent"/>
+                    <ref name="element.placeName"/>
+                    <ref name="element.eventDescription"/>
+                </choice>
             </zeroOrMore>
         </element>   
     </define>

--- a/xml-schemas/eac-cpf/eac.rng
+++ b/xml-schemas/eac-cpf/eac.rng
@@ -5983,15 +5983,15 @@
                   </attribute>
                </optional>
             </interleave>
-            <ref name="date"/>
-            <optional>
-               <ref name="agent"/>
-            </optional>
-            <optional>
-               <ref name="placeName"/>
-            </optional>
+            <oneOrMore>
+               <ref name="date"/>
+            </oneOrMore>
             <zeroOrMore>
-               <ref name="eventDescription"/>
+               <choice>
+                  <ref name="agent"/>
+                  <ref name="placeName"/>
+                  <ref name="eventDescription"/>
+               </choice>
             </zeroOrMore>
          </group>
       </element>

--- a/xml-schemas/eac-cpf/eac.xsd
+++ b/xml-schemas/eac-cpf/eac.xsd
@@ -1457,13 +1457,12 @@
    </xs:complexType>
    <xs:complexType name="narrativeEvent">
       <xs:sequence>
-         <xs:element type="eac:date" name="date"/>
-         <xs:element type="eac:agent" name="agent" minOccurs="0"/>
-         <xs:element type="eac:placeName" name="placeName" minOccurs="0"/>
-         <xs:element type="eac:eventDescription"
-                     name="eventDescription"
-                     minOccurs="0"
-                     maxOccurs="unbounded"/>
+         <xs:element type="eac:date" name="date" maxOccurs="unbounded"/>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element type="eac:agent" name="agent"/>
+            <xs:element type="eac:placeName" name="placeName"/>
+            <xs:element type="eac:eventDescription" name="eventDescription"/>
+         </xs:choice>
       </xs:sequence>
       <xs:attribute name="audience" type="xs:token"/>
       <xs:attribute name="id" type="xs:ID"/>

--- a/xml-schemas/ead/ead-4-0.rng
+++ b/xml-schemas/ead/ead-4-0.rng
@@ -7577,15 +7577,15 @@
                   </attribute>
                </optional>
             </interleave>
-            <ref name="date"/>
-            <optional>
-               <ref name="agent"/>
-            </optional>
-            <optional>
-               <ref name="placeName"/>
-            </optional>
+            <oneOrMore>
+               <ref name="date"/>
+            </oneOrMore>
             <zeroOrMore>
-               <ref name="eventDescription"/>
+               <choice>
+                  <ref name="agent"/>
+                  <ref name="placeName"/>
+                  <ref name="eventDescription"/>
+               </choice>
             </zeroOrMore>
          </group>
       </element>

--- a/xml-schemas/ead/ead-4-0.xsd
+++ b/xml-schemas/ead/ead-4-0.xsd
@@ -1830,13 +1830,12 @@
    </xs:complexType>
    <xs:complexType name="narrativeEvent">
       <xs:sequence>
-         <xs:element type="ead:date" name="date"/>
-         <xs:element type="ead:agent" name="agent" minOccurs="0"/>
-         <xs:element type="ead:placeName" name="placeName" minOccurs="0"/>
-         <xs:element type="ead:eventDescription"
-                     name="eventDescription"
-                     minOccurs="0"
-                     maxOccurs="unbounded"/>
+         <xs:element type="ead:date" name="date" maxOccurs="unbounded"/>
+         <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element type="ead:agent" name="agent"/>
+            <xs:element type="ead:placeName" name="placeName"/>
+            <xs:element type="ead:eventDescription" name="eventDescription"/>
+         </xs:choice>
       </xs:sequence>
       <xs:attribute name="audience" type="xs:token"/>
       <xs:attribute name="id" type="xs:ID"/>


### PR DESCRIPTION
Updated the content model for `<narrativeEvent>` following the decision in #238 to have all sub-elements repeatable; removed the already commented alternative modelling for `<biogHist>` as this is now the same in EAD and EAC-CPF